### PR TITLE
package.jsonにgrunt-text-replace追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt-eslint": "^17.1.0",
     "grunt-spritesmith": "^4.5.2",
     "grunt-styledocco": "^0.2.1",
+    "grunt-text-replace": "^0.4.0",
     "handlebars-helper-minify": "^0.1.3",
     "handlebars-helpers": "^0.5.8",
     "jit-grunt": "^0.9.1",


### PR DESCRIPTION
@sekiyaeiji さん
package.jsonに、納品用のみcssで読み込む背景画像パスを絶対パスに書き換えるため、grunt-text-replaceを追加しました。
ご確認をお願いします。