### PR TITLE
ESLint ルール適用

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+bin
+dist
+src/js/lib.js
+Gruntfile.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "extends": ["eslint-config-gnavi/legacy"],
+  "env": {
+    "browser": true,
+    "node": false
+  },
+  "globals": {
+    "PROJECTNAMESPACE": true,
+    "$": true,
+    "jQuery": true
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,28 +1,28 @@
 /**
- * grunt-boiler
- * 
+ * gnavi-grunt-boiler-assemble
+ *
  * ** 開発開始手順
- * 
+ *
  * $ npm install
  * $ grunt sprite
  * $ grunt
- * 
+ *
  * ** 開発watchコマンド
- * 
+ *
  * $ grunt watch
- * 
+ *
  * ** spriteコマンド
- * 
+ *
  * $ grunt sprite
- * 
- * ** jshintコマンド
- * 
+ *
+ * ** eslintコマンド
+ *
  * $ grunt test
- * 
+ *
  * ** dist、tmp削除コマンド
- * 
+ *
  * $ grunt clean
- * 
+ *
  * ---------------------------------------------------------------------- */
 
 module.exports = function (grunt) {
@@ -251,10 +251,6 @@ module.exports = function (grunt) {
     },
 
     // test
-    jshint: {
-      all: ['Gruntfile.js', '<%= path.js_src %>all/*.js']
-    },
-
     eslint: {
       options: {},
       target: ['<%= path.js_src %>all/*.js']
@@ -268,10 +264,10 @@ module.exports = function (grunt) {
   grunt.registerTask('build:html', ['assemble']);
   grunt.registerTask('build:copy', ['copy']);
   grunt.registerTask('build', ['build:css', 'build:js', 'build:html', 'build:copy']);
-  grunt.registerTask('test', ['jshint', 'eslint']);
+  grunt.registerTask('test', ['eslint']);
   grunt.registerTask('styleguide', ['build', 'styledocco']);
   grunt.registerTask('default', ['build']);
-  
+
   // option task
   grunt.registerTask('local', 'build for local', function () {
     grunt.config.set('assemble.files.options.statPath', '../');

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "",
+  "name": "gnavi-grunt-boiler-assemble",
   "version": "1.1.0",
   "description": "grunt boilerplate for gnavi front-end development",
   "homepage": "",
   "main": "index",
   "scripts": {
-    "build": "grunt eslint",
+    "clean": "grunt clean",
+    "sprite": "grunt sprite",
+    "build": "grunt local",
+    "build:dev": "grunt dev",
     "test": "grunt test",
+    "styleguide": "grunt styleguide",
+    "watch": "grunt watch",
     "stats": "./node_modules/stylestats/bin/cli.js dist/css/*.css -f csv > stats.csv"
   },
   "author": "",
@@ -15,7 +20,7 @@
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "babelify": "^7.2.0",
-    "eslint-config-gnavi": "0.0.8",
+    "eslint-config-gnavi": "^1.0.0-beta1",
     "grunt": "^0.4.5",
     "grunt-assemble": "^0.4.0",
     "grunt-autoprefixer": "^3.0.0",
@@ -26,13 +31,12 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "^0.13.0",
-    "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-csscomb": "^3.0.0",
     "grunt-csso": "^0.6.3",
-    "grunt-eslint": "^17.1.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-spritesmith": "^4.5.2",
     "grunt-styledocco": "^0.2.1",
     "grunt-text-replace": "^0.4.0",
@@ -42,13 +46,8 @@
     "stylestats": "^5.4.2",
     "time-grunt": "^1.2.1"
   },
-  "eslintConfig": {
-    "extends": [
-      "eslint-config-gnavi"
-    ]
-  },
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/gurunavi-creators/grunt-boiler.git"
+    "url": "git+ssh://github.com/gurunavi-creators/gnavi-grunt-boiler-assemble.git"
   }
 }

--- a/src/js/all/sample_a.js
+++ b/src/js/all/sample_a.js
@@ -1,50 +1,25 @@
 /**
- * grunt-boiler
+ * gnavi-grunt-boiler-assemble
  * all.js - sample_a.js
  * Author: sekiya
  * ---------------------------------------------------------------------- */
-// run
-$(function () {
-    sampleA.init();
-    sampleFunction1();
-});
 
 // sample A module
 var sampleA = {
-    init: function () {
-        PROJECTNAMESPACE.Utility.console('A');
-    }
-};
+  init: function init() {
+    PROJECTNAMESPACE.Utility.console('A')
+  }
+}
 
 // sample function
-var sampleFunction1 = function () {
-    var hoge1 = 1;
-    var huga1 = 2;
+function sampleFunction1() {
+  var hoge = '1'
+  var huga = '2'
+  return hoge + huga
+}
 
-    var hoge2 = 1;
-    var huga2 = 2;
-
-    var hoge3 = 1;
-    var huga3 = 2;
-
-    var hoge4 = 1;
-    var huga4 = 2;
-
-    var hoge5 = 1;
-    var huga5 = 2;
-
-    var hoge6 = 1;
-    var huga6 = 2;
-
-    var hoge7 = 1;
-    var huga7 = 2;
-
-    var hoge8 = 1;
-    var huga8 = 2;
-
-    var hoge9 = 1;
-    var huga9 = 2;
-
-    var hoge10 = 1;
-    var huga10 = 2;
-};
+// run
+$(function run() {
+  sampleA.init()
+  sampleFunction1()
+})

--- a/src/js/all/sample_b.js
+++ b/src/js/all/sample_b.js
@@ -1,50 +1,25 @@
 /**
- * grunt-boiler
+ * gnavi-grunt-boiler-assemble
  * all.js - sample_b.js
  * Author: sekiya
  * ---------------------------------------------------------------------- */
-// run
-$(function () {
-    sampleB.init();
-    sampleFunction2();
-});
 
 // sample B module
 var sampleB = {
-    init: function () {
-        PROJECTNAMESPACE.Utility.console('B');
-    }
-};
+  init: function init() {
+    PROJECTNAMESPACE.Utility.console('B')
+  }
+}
 
 // sample function
-var sampleFunction2 = function () {
-    var hoge1 = 1;
-    var huga1 = 2;
+function sampleFunction2() {
+  var hoge = '1'
+  var huga = '2'
+  return hoge + huga
+}
 
-    var hoge2 = 1;
-    var huga2 = 2;
-
-    var hoge3 = 1;
-    var huga3 = 2;
-
-    var hoge4 = 1;
-    var huga4 = 2;
-
-    var hoge5 = 1;
-    var huga5 = 2;
-
-    var hoge6 = 1;
-    var huga6 = 2;
-
-    var hoge7 = 1;
-    var huga7 = 2;
-
-    var hoge8 = 1;
-    var huga8 = 2;
-
-    var hoge9 = 1;
-    var huga9 = 2;
-
-    var hoge10 = 1;
-    var huga10 = 2;
-};
+// run
+$(function run() {
+  sampleB.init()
+  sampleFunction2()
+})

--- a/src/js/all/utility.js
+++ b/src/js/all/utility.js
@@ -1,61 +1,24 @@
 /**
- * grunt-boiler
+ * gnavi-grunt-boiler-assemble
  * all.js - utility.js
  * Author: sekiya
  * ---------------------------------------------------------------------- */
+
 PROJECTNAMESPACE.Utility = {
-    console: function (value) {
-        value = value || null;
-        console.log(value);
-    },
+  console: function (value) {
+    var value2 = value || null
+    console.log(value2)
+  },
 
-    sampleUtility1: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
+  sampleUtility1: function () {
+    var hoge = '1'
+    var huga = '2'
+    return hoge + huga
+  },
 
-    sampleUtility2: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility3: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility4: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility5: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility6: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility7: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility8: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility9: function () {
-        var hoge = 1;
-        var huga = 2;
-    },
-
-    sampleUtility10: function () {
-        var hoge = 1;
-        var huga = 2;
-    }
-};
+  sampleUtility2: function () {
+    var hoge = '1'
+    var huga = '2'
+    return hoge + huga
+  }
+}


### PR DESCRIPTION
eslint-config-gnavi の最新ルール適用に合わせて以下修正を行なっています。
- eslint-config-gnavi を 1.0.0 beta へアップグレード
- Linter を ESLint に統合するため、 JSHint を削除
- ESLint の最新ルールで該当する `src/js` 配下のエラー修正
- package.json の不足情報補足